### PR TITLE
Add support for .NET 6.0 and Source Link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+
     - name: Setup .NET 5.0
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+
     - name: Setup .NET 5.0
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,6 +22,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Setup .NET 6.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.0.x
+
     - name: Setup .NET 5.0
       uses: actions/setup-dotnet@v1
       with:

--- a/GeographicLib/CMathNative.cs
+++ b/GeographicLib/CMathNative.cs
@@ -12,8 +12,7 @@ namespace GeographicLib
 #if NET5_0_OR_GREATER
     class CMathNative : CMath
     {
-        [ModuleInitializer]
-        internal static void Init()
+        static CMathNative()
         {
             NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), (libraryName, assembly, searchPath) =>
             {

--- a/GeographicLib/Ellipsoid.cs
+++ b/GeographicLib/Ellipsoid.cs
@@ -113,14 +113,14 @@ namespace GeographicLib
         /// the ellipsoid.This is zero, positive, or negative for a sphere,
         /// oblate ellipsoid, or prolate ellipsoid.
         /// </summary>
-        public double SecondFlatterning => _f / (1 - _f);
+        public double SecondFlattening => _f / (1 - _f);
 
         /// <summary>
         /// <i>n</i> = (<i>a</i> - <i>b</i>) / (<i>a</i> + <i>b</i>), the third flattening
         /// of the ellipsoid.This is zero, positive, or negative for a sphere,
         /// oblate ellipsoid, or prolate ellipsoid.
         /// </summary>
-        public double ThirdFlatterning => _n;
+        public double ThirdFlattening => _n;
 
         /// <summary>
         /// <i>e</i>^2 = (<i>a</i>^2 - <i>b</i>^2) / <i>a</i>^2, the eccentricity squared

--- a/GeographicLib/Geodesic.cs
+++ b/GeographicLib/Geodesic.cs
@@ -1295,7 +1295,7 @@ namespace GeographicLib
 
             // Swap points so that point with higher (abs) latitude is point 1.
             // If one latitude is a nan, then it becomes lat1.
-            int swapp = Abs(lat1) < Abs(lat2) ? -1 : 1;
+            int swapp = Abs(lat1) < Abs(lat2) || double.IsNaN(lat2) ? -1 : 1;
             if (swapp < 0)
             {
                 lonsign *= -1;

--- a/GeographicLib/GeodesicExact.cs
+++ b/GeographicLib/GeodesicExact.cs
@@ -528,7 +528,7 @@ namespace GeographicLib
             lat2 = AngRound(LatFix(lat2));
             // Swap points so that point with higher (abs) latitude is point 1
             // If one latitude is a nan, then it becomes lat1.
-            int swapp = Abs(lat1) < Abs(lat2) ? -1 : 1;
+            int swapp = Abs(lat1) < Abs(lat2) || double.IsNaN(lat2) ? -1 : 1;
             if (swapp < 0)
             {
                 lonsign *= -1;

--- a/GeographicLib/GeographicLib.csproj
+++ b/GeographicLib/GeographicLib.csproj
@@ -17,7 +17,7 @@
 
 GeographicLib.NET is a native .NET implementation of GeographicLib written in pure C#.</Description>
     <Copyright>Copyright (c) 2021 GeographicLib.NET contributors</Copyright>
-    <VersionPrefix>1.52.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <PackageTags>gis, geodesic, geographic, geoid, geomagnetic, gravity, projection, rhumb</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>SigningKey.snk</AssemblyOriginatorKeyFile>

--- a/GeographicLib/GeographicLib.csproj
+++ b/GeographicLib/GeographicLib.csproj
@@ -1,38 +1,55 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\GeographicLib.xml</DocumentationFile>
-    <DefineConstants>x__FP_FAST_FMA</DefineConstants>
-    <PackageId>GeographicLib.NET</PackageId>
-    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>https://github.com/noelex/GeographicLib.NET</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/noelex/GeographicLib.NET.git</RepositoryUrl>
-    <Authors>noelex</Authors>
-    <Product>GeographicLib.NET</Product>
-    <Company />
-    <Description>GeographicLib is a small set of C++ classes for performing conversions between geographic, UTM, UPS, MGRS, geocentric, and local cartesian coordinates,for gravity (e.g., EGM2008), geoid height and geomagnetic field (e.g., WMM2020) calculations, and for solving geodesic problems.
+	<PropertyGroup>
+		<TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\GeographicLib.xml</DocumentationFile>
+		<DefineConstants>x__FP_FAST_FMA</DefineConstants>
+		<PackageId>GeographicLib.NET</PackageId>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<RepositoryType>git</RepositoryType>
+		<PackageProjectUrl>https://github.com/noelex/GeographicLib.NET</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/noelex/GeographicLib.NET.git</RepositoryUrl>
+		<Authors>noelex</Authors>
+		<Product>GeographicLib.NET</Product>
+		<Company />
+		<Description>
+			GeographicLib is a small set of C++ classes for performing conversions between geographic, UTM, UPS, MGRS, geocentric, and local cartesian coordinates,for gravity (e.g., EGM2008), geoid height and geomagnetic field (e.g., WMM2020) calculations, and for solving geodesic problems.
 
-GeographicLib.NET is a native .NET implementation of GeographicLib written in pure C#.</Description>
-    <Copyright>Copyright (c) 2021 GeographicLib.NET contributors</Copyright>
-    <VersionPrefix>1.52.1</VersionPrefix>
-    <PackageTags>gis, geodesic, geographic, geoid, geomagnetic, gravity, projection, rhumb</PackageTags>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>SigningKey.snk</AssemblyOriginatorKeyFile>
-    <PublicSign>True</PublicSign>
-  </PropertyGroup>
+			GeographicLib.NET is a native .NET implementation of GeographicLib written in pure C#.
+		</Description>
+		<Copyright>Copyright (c) 2021 GeographicLib.NET contributors</Copyright>
+		<VersionPrefix>1.52.1</VersionPrefix>
+		<PackageTags>gis, geodesic, geographic, geoid, geomagnetic, gravity, projection, rhumb</PackageTags>
+		<SignAssembly>true</SignAssembly>
+		<AssemblyOriginatorKeyFile>SigningKey.snk</AssemblyOriginatorKeyFile>
+		<PublicSign>True</PublicSign>
+	</PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="System.Memory" Version="4.5.4" />
-    <PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
-  </ItemGroup>
+	<PropertyGroup>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<EmbedUntrackedSources>true</EmbedUntrackedSources>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
+	<PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+	</PropertyGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+		<PackageReference Include="System.Memory" Version="4.5.4" />
+		<PackageReference Include="System.Runtime.Extensions" Version="4.3.1" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
 </Project>

--- a/GeographicLib/GeographicLib.csproj
+++ b/GeographicLib/GeographicLib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netstandard2.1;netstandard2.0</TargetFrameworks>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\GeographicLib.xml</DocumentationFile>
     <DefineConstants>x__FP_FAST_FMA</DefineConstants>
     <PackageId>GeographicLib.NET</PackageId>
@@ -17,7 +17,7 @@
 
 GeographicLib.NET is a native .NET implementation of GeographicLib written in pure C#.</Description>
     <Copyright>Copyright (c) 2021 GeographicLib.NET contributors</Copyright>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>1.52.1</VersionPrefix>
     <PackageTags>gis, geodesic, geographic, geoid, geomagnetic, gravity, projection, rhumb</PackageTags>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>SigningKey.snk</AssemblyOriginatorKeyFile>

--- a/GeographicLib/MathEx.cs
+++ b/GeographicLib/MathEx.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Text;
-
-using static System.Math;
 using static GeographicLib.Macros;
+using static System.Math;
 
 namespace GeographicLib
 {
@@ -349,7 +344,15 @@ namespace GeographicLib
             r = Remquo(x, 90, out var q);
             r *= Degree;
 
+#if NET6_0_OR_GREATER
+            // TODO: Math.SinCos is failing test case PlanimeterTests.TestComputeWithPoints on Windows,
+            // procuding error ranging from 0.0002 to 0.02 meters, which is much greater than expected error 1e-8.
+            // Needs further investigation.
+            // var (s, c) = SinCos(r);
+            var (s, c) = (Sin(r), Cos(r));
+#else
             double s = Sin(r), c = Cos(r);
+#endif
 
             switch ((uint)q & 3U)
             {

--- a/GeographicLib/NormalGravity.cs
+++ b/GeographicLib/NormalGravity.cs
@@ -383,7 +383,7 @@ namespace GeographicLib
         /// <summary>
         /// A global instantiation of <see cref="NormalGravity"/> for the WGS84 ellipsoid.
         /// </summary>
-        public static NormalGravity WGS84 =>
+        public static NormalGravity WGS84 { get; } =
                 new NormalGravity(
                     Constants.WGS84_a,
                     Constants.WGS84_GM,
@@ -395,7 +395,7 @@ namespace GeographicLib
         /// <summary>
         /// A global instantiation of <see cref="NormalGravity"/> for the GRS80 ellipsoid.
         /// </summary>
-        public static NormalGravity GRS80 =>
+        public static NormalGravity GRS80 { get; } =
                 new NormalGravity(
                     Constants.GRS80_a,
                     Constants.GRS80_GM,

--- a/GeographicLib/Projections/AlbersEqualArea.cs
+++ b/GeographicLib/Projections/AlbersEqualArea.cs
@@ -1,8 +1,6 @@
-﻿using System;
-
-using static System.Math;
+﻿using static GeographicLib.Macros;
 using static GeographicLib.MathEx;
-using static GeographicLib.Macros;
+using static System.Math;
 
 namespace GeographicLib.Projections
 {
@@ -41,11 +39,6 @@ namespace GeographicLib.Projections
         private readonly double _n0, _m02, _nrho0, _txi0, _scxi0, _sxi0;
 
         private double _k0, _k2;
-
-        private static readonly AlbersEqualArea
-            _cylindrical = new AlbersEqualArea(Constants.WGS84_a, Constants.WGS84_f, 0, 1, 0, 1, 1),
-            _north = new AlbersEqualArea(Constants.WGS84_a, Constants.WGS84_f, 1, 0, 1, 0, 1),
-            _south = new AlbersEqualArea(Constants.WGS84_a, Constants.WGS84_f, 1, 0, 1, 0, 1);
 
         /// <summary>
         /// Newton iterations in Reverse
@@ -86,7 +79,7 @@ namespace GeographicLib.Projections
         /// <param name="stdlat2">second standard parallel (degrees).</param>
         /// <param name="k1">azimuthal scale on the standard parallels.</param>
         public AlbersEqualArea(IEllipsoid ellipsoid, double stdlat1, double stdlat2, double k1)
-            :this(ellipsoid.EquatorialRadius, ellipsoid.Flattening, stdlat1, stdlat2, k1) { }
+            : this(ellipsoid.EquatorialRadius, ellipsoid.Flattening, stdlat1, stdlat2, k1) { }
 
         /// <summary>
         /// Constructor with a single standard parallel.
@@ -218,26 +211,26 @@ namespace GeographicLib.Projections
         /// <i>stdlat</i> = 0, and <i>k0</i> = 1.This degenerates to the cylindrical equalarea projection.
         /// </summary>
         /// <returns></returns>
-        public static AlbersEqualArea Cylindrical => _cylindrical.IsFrozen ? _cylindrical : _cylindrical.Freeze();
+        public static AlbersEqualArea Cylindrical { get; } = new AlbersEqualArea(Constants.WGS84_a, Constants.WGS84_f, 0, 1, 0, 1, 1).Freeze();
 
         /// <summary>
         /// A global instantiation of <see cref="AlbersEqualArea"/> with the WGS84 ellipsoid, 
         /// <i>stdlat</i> = 90°, and <i>k0</i> = 1.This degenerates to the Lambert azimuthal equal area projection.
         /// </summary>
         /// <returns></returns>
-        public static AlbersEqualArea North => _north.IsFrozen ? _north : _north.Freeze();
+        public static AlbersEqualArea North { get; } = new AlbersEqualArea(Constants.WGS84_a, Constants.WGS84_f, 1, 0, 1, 0, 1).Freeze();
 
         /// <summary>
         /// A global instantiation of <see cref="AlbersEqualArea"/> with the WGS84 ellipsoid, 
         /// <i>stdlat</i> = -90°, and <i>k0</i> = 1.This degenerates to the Lambert azimuthal equal area projection.
         /// </summary>
         /// <returns></returns>
-        public static AlbersEqualArea South() => _south.IsFrozen ? _south : _south.Freeze();
+        public static AlbersEqualArea South { get; } = new AlbersEqualArea(Constants.WGS84_a, Constants.WGS84_f, -1, 0, -1, 0, 1).Freeze();
 
         /// <summary>
         /// Freeze current <see cref="AlbersEqualArea"/> instance to prevent its scale being modified.
         /// </summary>
-        public AlbersEqualArea Freeze() { IsFrozen = false; return this; }
+        public AlbersEqualArea Freeze() { IsFrozen = true; return this; }
 
         /// <summary>
         /// Set the azimuthal scale for the projection.
@@ -401,8 +394,8 @@ namespace GeographicLib.Projections
                 // taking log2 of both sides, a stronger condition is
                 // (n-1)*(-e) < -lg2eps or (n-1)*e > lg2eps or n > ceiling(lg2eps/e)+1
                 int n = x == 0 ? 1 : (int)Ceiling(lg2eps_ / e) + 1;
-                while (n--!=0)               // iterating from n-1 down to 0
-                    s = x * s + (n!=0 ? 1 : 0) / (double)(2 * n + 1);
+                while (n-- != 0)               // iterating from n-1 down to 0
+                    s = x * s + (n != 0 ? 1 : 0) / (double)(2 * n + 1);
             }
             else
             {
@@ -445,8 +438,8 @@ namespace GeographicLib.Projections
 
         // Rearrange difference so that 1 - x is in the denominator, then do a
         // straight divided difference.
-        private double DDAtanhEE0(double x, double y) 
-            => (DAtanhEE(1, y) - DAtanhEE(x, y))/(1 - x);
+        private double DDAtanhEE0(double x, double y)
+            => (DAtanhEE(1, y) - DAtanhEE(x, y)) / (1 - x);
 
         // The expansion for e2 small
         private double DDAtanhEE1(double x, double y)
@@ -466,7 +459,8 @@ namespace GeographicLib.Projections
             // Use if e2 is sufficiently small.
             var s = 0d;
             double z = 1, k = 1, t = 0, c = 0, en = 1;
-            while (true) {
+            while (true)
+            {
                 t = y * t + z; c += t; z *= x;
                 t = y * t + z; c += t; z *= x;
                 k += 2; en *= _e2;

--- a/GeographicLib/Projections/LambertConformalConic.cs
+++ b/GeographicLib/Projections/LambertConformalConic.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿using static GeographicLib.MathEx;
 using static System.Math;
-using static GeographicLib.MathEx;
 
 namespace GeographicLib.Projections
 {
@@ -87,7 +83,7 @@ namespace GeographicLib.Projections
         /// or if either <paramref name="stdlat1"/> or <paramref name="stdlat2"/> is a pole and <paramref name="stdlat1"/> is not equal <paramref name="stdlat2"/>.
         /// </exception>
         public LambertConformalConic(IEllipsoid ellipsoid, double stdlat1, double stdlat2, double k1)
-            :this(ellipsoid.EquatorialRadius, ellipsoid.Flattening, stdlat1, stdlat2, k1) { }
+            : this(ellipsoid.EquatorialRadius, ellipsoid.Flattening, stdlat1, stdlat2, k1) { }
 
         /// <summary>
         /// Constructor with a single standard parallel.
@@ -552,7 +548,7 @@ namespace GeographicLib.Projections
         /// <summary>
         /// Freeze current <see cref="LambertConformalConic"/> instance to prevent its scale being modified.
         /// </summary>
-        public LambertConformalConic Freeze() { IsFrozen = false; return this; }
+        public LambertConformalConic Freeze() { IsFrozen = true; return this; }
 
         /// <summary>
         /// Set the scale for the projection.

--- a/GeographicLib/Projections/PolarStereographic.cs
+++ b/GeographicLib/Projections/PolarStereographic.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿using static GeographicLib.MathEx;
 using static System.Math;
-using static GeographicLib.MathEx;
 
 namespace GeographicLib.Projections
 {
@@ -30,8 +26,6 @@ namespace GeographicLib.Projections
     {
         private readonly double _a, _f, _e2, _es, _e2m, _c;
         private double _k0;
-
-        private static readonly PolarStereographic _ups = new PolarStereographic(Ellipsoid.WGS84, Constants.UPS_k0);
 
         /// <summary>
         /// Initialize a new <see cref="PolarStereographic"/> instance with specified ellipsoid and scale.
@@ -71,7 +65,7 @@ namespace GeographicLib.Projections
         /// A global instantiation of <see cref="PolarStereographic"/> with
         /// the WGS84 ellipsoid and the UPS scale factor. However, unlike UPS, no false easting or northing is added.
         /// </summary>
-        public static PolarStereographic UPS => _ups.IsFrozen ? _ups : _ups.Freeze();
+        public static PolarStereographic UPS { get; } = new PolarStereographic(Ellipsoid.WGS84, Constants.UPS_k0);
 
         /// <summary>
         /// Gets a value representing central scale for the projection.  This is the azimuthal scale on the latitude of origin.
@@ -96,7 +90,7 @@ namespace GeographicLib.Projections
         /// <summary>
         /// Freeze current <see cref="PolarStereographic"/> instance to prevent its scale being modified.
         /// </summary>
-        public PolarStereographic Freeze() { IsFrozen = false; return this; }
+        public PolarStereographic Freeze() { IsFrozen = true; return this; }
 
         /// <summary>
         /// Forward projection, from geographic to projected coordinate system.

--- a/GeographicLibTests/GeodSolveTests.cs
+++ b/GeographicLibTests/GeodSolveTests.cs
@@ -486,5 +486,35 @@ namespace GeographicLib.Tests
             Assert.IsTrue(double.IsNaN(lon2));
             Assert.IsTrue(double.IsNaN(azi2));
         }
+
+        [TestMethod]
+        public void GeodSolve92_CheckFixForInaccurateHypotWithPython()
+        {
+            var result = Geodesic.WGS84.Inverse(37.757540000000006, -122.47018, 37.75754, -122.470177);
+            var resultExact = GeodesicExact.WGS84.Inverse(37.757540000000006, -122.47018, 37.75754, -122.470177);
+
+            Assert.AreEqual(89.9999992, result.Azimuth1, 1e-7);
+            Assert.AreEqual(90.000001, result.Azimuth2, 1e-6);
+            Assert.AreEqual(0.264, result.Distance, 1e-3);
+
+            Assert.AreEqual(89.9999992, resultExact.Azimuth1, 1e-7);
+            Assert.AreEqual(90.000001, resultExact.Azimuth2, 1e-6);
+            Assert.AreEqual(0.264, resultExact.Distance, 1e-3);
+        }
+
+        [TestMethod]
+        public void GeodSolve94_CheckFixFor_lat2_eq_NaN_BeingTreatedAs_lat2_eq_Zero()
+        {
+            var result = Geodesic.WGS84.Inverse(0, 0, double.NaN, 90);
+            var resultExact = GeodesicExact.WGS84.Inverse(0, 0, double.NaN, 90);
+
+            Assert.IsTrue(double.IsNaN(result.Azimuth1));
+            Assert.IsTrue(double.IsNaN(result.Azimuth2));
+            Assert.IsTrue(double.IsNaN(result.Distance));
+
+            Assert.IsTrue(double.IsNaN(resultExact.Azimuth1));
+            Assert.IsTrue(double.IsNaN(resultExact.Azimuth2));
+            Assert.IsTrue(double.IsNaN(resultExact.Distance));
+        }
     }
 }

--- a/GeographicLibTests/GeographicLibTests.csproj
+++ b/GeographicLibTests/GeographicLibTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <IsPackable>false</IsPackable>
     <RootNamespace>GeographicLib.Tests</RootNamespace>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ GeographicLib.NET is a native .NET implementation of [GeographicLib](https://sou
 
 ## What's different from NETGeographicLib
 
-Unlike the original NETGeographicLib, GeographicLib.NET is implemented in pure C# without binding the original C++ GeograpbicLib library by using C++/CLI or P/Invoke, thus achieves higher level of portability.
+Unlike NETGeographicLib, GeographicLib.NET is implemented in pure C# without binding the C++ GeograpbicLib library by using C++/CLI or P/Invoke, thus achieves higher level of portability.
 
 You should be able to use GeographicLib.NET with any target framework and platform that supports .NET Standard 2.0 or above.
 
@@ -76,14 +76,14 @@ These functions provide better performance, but may produce inconsistent results
 
 ## Documentation
 GeographicLib.NET includes a detailed XML documentation for all public APIs.
-Since the API surface of GeographicLib.NET is highly compatible with the original GeographicLib,
-you can also refer the original documentation [here](https://geographiclib.sourceforge.io/html/index.html) for usage and explanation.
+Since the API surface of GeographicLib.NET is highly compatible with GeographicLib,
+you can also refer the its documentation [here](https://geographiclib.sourceforge.io/html/index.html) for usage and detailed explanation.
 
 ## Change Log
-GeographicLib.NET adopts changes made in original GeographicLib and aligns its version number with original GeographicLib releases.
+GeographicLib.NET adopts changes made in GeographicLib and aligns its version number with GeographicLib releases.
 
 Bellow is a list of stable releases of GeographicLib.NET and changes made in .NET side in each release.
-For changes adopted from original GeographicLib, please refer the its change log [here](https://geographiclib.sourceforge.io/html/changes.html).
+For changes adopted from GeographicLib, please refer the its change log [here](https://geographiclib.sourceforge.io/html/changes.html).
 
 ### Version 1.52.1 (unreleased)
 - **NEW**
@@ -94,7 +94,7 @@ For changes adopted from original GeographicLib, please refer the its change log
   - Fixed typos in `Ellipsoid`. (Renamed `SecondFlatterning` to `SecondFlattening` and `ThirdFlatterning` to `ThirdFlattening`)
 
 - **FIX**
-  - Fixed the issue that `Freeze` method in `AlbersEqualArea`, `LambertConformalConic` and `PolarStereographic` was not working correctly.
+  - Fixed an issue that `Freeze` method in `AlbersEqualArea`, `LambertConformalConic` and `PolarStereographic` was not working correctly.
   - Fixed duplicate instantiation of `WGS84` and `GRS80` static properties defined in `NormalGravity`.
   - [Add missing support for World Magnetic Model Format v2](https://github.com/noelex/GeographicLib.NET/issues/17).
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ For changes adopted from original GeographicLib, please refer the its change log
 
 ### Version 1.52.1 (unreleased)
 - **NEW**
-  - GeographicLib.NET also targets .NET 6.0 now.
+  - Target .NET 6.0 in addition to .NET 5.0, .NET Standard 2.1 and .NET Standard 2.0.
+  - [Source Link](https://github.com/dotnet/sourcelink) support.
 
 - **BREAKING**
   - Fixed typos in `Ellipsoid`. (Renamed `SecondFlatterning` to `SecondFlattening` and `ThirdFlatterning` to `ThirdFlattening`)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ GeographicLib.NET adopts changes made in GeographicLib and aligns its version nu
 Bellow is a list of stable releases of GeographicLib.NET and changes made in .NET side in each release.
 For changes adopted from GeographicLib, please refer the its change log [here](https://geographiclib.sourceforge.io/html/changes.html).
 
-### Version 1.52.1 (unreleased)
+### Version 1.52.1 (released 2022/04/12)
 - **NEW**
   - Target .NET 6.0 in addition to .NET 5.0, .NET Standard 2.1 and .NET Standard 2.0.
   - [Source Link](https://github.com/dotnet/sourcelink) support.

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ GeographicLib.NET adopts changes made in original GeographicLib and aligns its v
 Bellow is a list of stable releases of GeographicLib.NET and changes made in .NET side in each release.
 For changes adopted from original GeographicLib, please refer the its change log [here](https://geographiclib.sourceforge.io/html/changes.html).
 
+### Version 2.0.0 (unreleased)
+- **BREAKING**
+  - Fixed typos in `Ellipsoid`. (`SecondFlatterning` to `SecondFlattening` and `ThirdFlatterning` to `ThirdFlattening`)
+
+- **FIX**
+  - Fixed the issue that `Freeze` method in `AlbersEqualArea`, `LambertConformalConic` and `PolarStereographic` was not working correctly.
+  - Fixed duplicate instantiation of `WGS84` and `GRS80` static properties defined in `NormalGravity`.
+
 ### Version 1.52.0 (released 2021/07/07)
 - **BREAKING**
   - Modify overloads of `Forward` and `Reverse` in `AlbersEqualArea`, `AzimuthalEquidistant`, `CassiniSoldner` and `LambertConformalConic` to return coordinates as tuples.

--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ GeographicLib uses several C mathematical functions that are not available in al
 
 GeographicLib.NET provides managed implementations of these functions (ported from [musl libc](https://musl.libc.org/)).
 
-`GeographicLib.MathEx` class will use implementations provided by .NET runtime whenenver possible, and will fallback to managed implementations when not available in .NET runtime. 
+`GeographicLib.MathEx` class will use implementations provided by .NET runtime whenever possible, and will fallback to managed implementations when not available in .NET runtime. 
 
 You can also force `GeographicLib.MathEx` to fallback to platform dependent implementations provided by system C runtime libraries,
 rather than managed implementations, by setting `GeographicLib.MathEx.UseManagedCMath` property to `false`.
-These functions provide better performance, but may produce different results on different platform in some edge cases.
+These functions provide better performance, but may produce inconsistent results on different platforms in some edge cases.
 
 ## Documentation
 GeographicLib.NET includes a detailed XML documentation for all public APIs.
@@ -85,14 +85,17 @@ GeographicLib.NET adopts changes made in original GeographicLib and aligns its v
 Bellow is a list of stable releases of GeographicLib.NET and changes made in .NET side in each release.
 For changes adopted from original GeographicLib, please refer the its change log [here](https://geographiclib.sourceforge.io/html/changes.html).
 
-### Version 2.0.0 (unreleased)
+### Version 1.52.1 (unreleased)
+- **NEW**
+  - GeographicLib.NET also targets .NET 6.0 now.
+
 - **BREAKING**
-  - Fixed typos in `Ellipsoid`. (`SecondFlatterning` to `SecondFlattening` and `ThirdFlatterning` to `ThirdFlattening`)
+  - Fixed typos in `Ellipsoid`. (Renamed `SecondFlatterning` to `SecondFlattening` and `ThirdFlatterning` to `ThirdFlattening`)
 
 - **FIX**
   - Fixed the issue that `Freeze` method in `AlbersEqualArea`, `LambertConformalConic` and `PolarStereographic` was not working correctly.
   - Fixed duplicate instantiation of `WGS84` and `GRS80` static properties defined in `NormalGravity`.
-  - Add support for Word Magnetic Model Format v2 ([issue #17](https://github.com/noelex/GeographicLib.NET/issues/17)).
+  - [Add missing support for World Magnetic Model Format v2](https://github.com/noelex/GeographicLib.NET/issues/17).
 
 ### Version 1.52.0 (released 2021/07/07)
 - **BREAKING**


### PR DESCRIPTION
This PR adds support for .NET 6.0 and Source Link to GeographicLib.NET.

I was thinking of replacing separate calls to `Math.Sin` and `Math.Cos` in `MathEx.SinCosd` with the brand new API `Math.SinCos`, which may bring  some performance gain.

But it seems that `Math.SinCos` is producing slightly inconsistent results on Windows, failing test `PlanimeterTests.TestComputeWithPoints`.

So for now there's no .NET 6.0 specific code in the repo, just getting ready to drop .NET 5.0 due to EOL.